### PR TITLE
Add List Recommendations button and update BDD for listing recommendations

### DIFF
--- a/features/recommendations.feature
+++ b/features/recommendations.feature
@@ -31,11 +31,15 @@ Feature: The recommendation service back-end
         And I should see "" in the "Recommended Product ID" field
         And the remembered recommendation should not exist
     
-    Scenario: List all recommendations
+    Scenario: List all recommendations via the admin UI
         Given the recommendation service is running
-        When I list all recommendations
-        Then the response status code should be "200"
-        And I should receive at least 2 recommendations
-        And I should see a recommendation with base product "1001" and recommended product "2001"
-        And I should see a recommendation with base product "3001" and recommended product "4001"
+        And I am on the "Home Page"
+        When I press the "List" button
+        Then I should see the message "Success"
+        And I should see at least 2 recommendations in the list
+        And I should see a recommendation with base product "1001" and recommended product "2001" in the list
+        And I should see a recommendation with base product "3001" and recommended product "4001" in the list
+    
+    
+
 

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -134,9 +134,10 @@
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <button type="submit" class="btn btn-primary" id="search-btn">Search</button>
-              <button type="submit" class="btn btn-primary" id="clear-btn">Clear</button>
+              <button type="submit" class="btn btn-info" id="list-btn">List</button>
               <button type="submit" class="btn btn-success" id="create-btn">Create</button>
               <button type="submit" class="btn btn-warning" id="update-btn">Update</button>
+              <button type="submit" class="btn btn-primary" id="clear-btn">Clear</button>
             </div>
           </div>
         </div> <!-- form horizontal -->

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -419,4 +419,26 @@ $(function () {
             handleAjaxFail(res, "Recommendation not found");
         });
     });
+
+    // === List all recommendations ===
+    $("#list-btn").click(function (event) {
+        event.preventDefault();
+        $("#flash_message").empty();
+
+        const ajax = $.ajax({
+            type: "GET",
+            url: API_BASE_URL,          // GET /recommendations (no filters)
+            contentType: "application/json",
+        });
+
+        ajax.done(function (res) {
+            renderResultsTable(res);    
+            flash_message("Success");
+        });
+
+        ajax.fail(function (res) {
+            $("#search_results").empty();
+            handleAjaxFail(res, "Unable to list recommendations");
+        });
+    });
 });


### PR DESCRIPTION
Changes:

- `index.html`
    - Added a new List button to the admin UI 
    - Adjusted button ordering : Search -> List -> Create -> Update -> Clear

- `rest_api.js`
    - Connected the List button to `GET /recommendations` endpoint (no filters)
    - If success: put all recommendations in the results table and show a "Success" flash message
    - If fail: clear the results area and display an error message: "Unable to list recommendations"
    
- `recommendations.feature`
    -  Modified the List recommendations scenario to use the UI
    - Press the “List” button
    - Expect the `Success` message
    - Verify that at least two recommendations are shown and that specific base/recommended product pairs appear in the list

- `recommendation_steps.py `
    - Updated step definitions to drive the UI
