### PR TITLE
[CD-pipeline][git-clone] Sync Tekton pipeline.yaml with OpenShift pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -20,13 +20,14 @@ spec:
 
   tasks:
     - name: git-clone
+      params:
+        - name: URL
+          value: $(params.git-repo)
+        - name: REVISION
+          value: $(params.git-ref)
       taskRef:
-        name: git-clone        
+        kind: Task
+        name: git-clone
       workspaces:
         - name: output
-          workspace: pipeline-workspace 
-      params:
-        - name: url
-          value: $(params.git-repo)
-        - name: revision
-          value: $(params.git-ref)
+          workspace: pipeline-workspace


### PR DESCRIPTION
- Updated `pipeline.yaml`
- Wired the params into `git-clone` task so URL and REVISION use `$(params.git-repo)` and `$(params.git-ref)`

Steps:

1. [local] change namespace in `pipeline.yaml`
2. [local] oc login
3. [local] `oc apply -f .tekton/`
4. [Openshift] confirm `git-clone` task set up
5. [Openshift] manually input params, finish all setting
6. [Openshift] copy YAML and paste it in [local] `pipeline.yaml`