### PR TITLE
[CD Pipeline] Create a Route to Provide External Access to the Recommendation Service

### DIFF
--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: recommendations
+spec:
+  to:
+    kind: Service
+    name: recommendations
+  port:
+    targetPort: 8080-tcp
+  tls:
+    termination: edge


### PR DESCRIPTION
 Summary
- move every REST endpoint under `/api`, updating Flask routes, UI JS, Behave steps, unit tests, README, and k8s probes
- add Tekton TriggerBinding/TriggerTemplate/EventListener (plus an OpenShift Route) so GitHub push events can trigger `recommendations-cd`
- expose the service externally via `k8s/route.yaml` and document how to apply it

Testing
- DATABASE_URI="sqlite:///test.db" pipenv run pytest
- oc apply -f k8s/service.yaml && oc apply -f k8s/route.yaml
- oc get route recommendations  # verified https://recommendations-ccyy111-dev.apps.rm1.0a51.p1.openshiftapps.com
